### PR TITLE
Resolves full content from file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.hateoas:spring-hateoas'
     implementation 'io.swagger.core.v3:swagger-models'
     implementation 'io.swagger.core.v3:swagger-core'
+    implementation 'io.swagger.parser.v3:swagger-parser-v3:2.1.16'
     testImplementation 'org.springframework:spring-test'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'io.cucumber:cucumber-java'

--- a/src/main/java/org/resthub/web/springmvc/router/parser/OpenApiRouteLoader.java
+++ b/src/main/java/org/resthub/web/springmvc/router/parser/OpenApiRouteLoader.java
@@ -1,8 +1,9 @@
 package org.resthub.web.springmvc.router.parser;
 
-import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.*;
 import io.swagger.v3.oas.models.PathItem.HttpMethod;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
 import org.resthub.web.springmvc.router.HTTPRequestAdapter;
 import org.resthub.web.springmvc.router.Router.Route;
 import org.resthub.web.springmvc.router.exceptions.RouteFileParsingException;
@@ -26,10 +27,13 @@ public class OpenApiRouteLoader {
 
     public List<Route> load(Resource data) {
 
-        try (InputStream fis = data.getInputStream()) {
-            OpenAPI loaded = Yaml.mapper().readValue(
-                    fis,
-                    OpenAPI.class
+        try (InputStream ignored = data.getInputStream()) {
+            ParseOptions parseOptions = new ParseOptions();
+            parseOptions.setResolveFully(true);
+            OpenAPI loaded = new OpenAPIV3Parser().read(
+                    data.getURL().toString(),
+                    null,
+                    parseOptions
             );
             List<Route> toRet = new ArrayList<>(loaded.getPaths().size() * 2);
 


### PR DESCRIPTION
The idea is to parse the configuration file and resolve the referenced content of an element with a copy in-line, hoping that this will make more easy the mapping afterwards.