### PR TITLE
feat: Copy spec to temp file before parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.avolpe:openapi-springmvc-router:2.2.1'
+    implementation 'com.github.avolpe:openapi-springmvc-router:2.2.2'
 }
 ```
 
@@ -28,7 +28,7 @@ If you're using Maven, add this to your `pom.xml`:
     <dependency>
         <groupId>com.github.avolpe</groupId>
         <artifactId>openapi-springmvc-router</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.github.avolpe'
-version = '2.2.1'
+version = '2.2.2'
 description = 'openapi-springmvc-router'
 
 repositories {

--- a/src/main/java/org/resthub/web/springmvc/router/parser/OpenApiRouteLoader.java
+++ b/src/main/java/org/resthub/web/springmvc/router/parser/OpenApiRouteLoader.java
@@ -15,6 +15,7 @@ import org.springframework.http.MediaType;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -28,10 +29,16 @@ public class OpenApiRouteLoader {
     public List<Route> load(Resource data) {
 
         try (InputStream ignored = data.getInputStream()) {
+
+            // Copy the spec to a file, this is needed because the parser don't work if the input stream is not a valid
+            // file, it can't resolve the dependencies inside the spec.
+            var tempFile = Files.createTempFile(data.getFilename(), ".yaml");
+            Files.copy(data.getInputStream(), tempFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+
             ParseOptions parseOptions = new ParseOptions();
             parseOptions.setResolveFully(true);
             OpenAPI loaded = new OpenAPIV3Parser().read(
-                    data.getURL().toString(),
+                    tempFile.toFile().getAbsolutePath(),
                     null,
                     parseOptions
             );


### PR DESCRIPTION
When running inside a jar, the open API parser can't resolve all links between components and logs a bunch of errors, with this change, the file is first copied to a temporal path and then parsed.